### PR TITLE
TabBar指示器断言错误

### DIFF
--- a/lib/src/page/log_detail.dart
+++ b/lib/src/page/log_detail.dart
@@ -78,21 +78,24 @@ class _LogDetailState extends State<LogDetail>
               ),
             ],
           ),
-          child: TabBar(
-              controller: _tabController,
-              unselectedLabelColor: Colors.black,
-              labelColor: Theme.of(context).primaryColor,
-              indicatorPadding: const EdgeInsets.symmetric(horizontal: 20),
-              labelStyle:
-                  const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
-              unselectedLabelStyle:
-                  const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
-              tabs: const [
-                Tab(text: 'Request'),
-                Tab(text: 'Response'),
-                Tab(text: 'Error'),
-                Tab(text: 'TryAgain'),
-              ]),
+          child: SafeArea(
+            child: TabBar(
+                controller: _tabController,
+                unselectedLabelColor: Colors.black,
+                labelColor: Theme.of(context).primaryColor,
+                indicatorPadding: const EdgeInsets.symmetric(horizontal: 20),
+                labelStyle:
+                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                unselectedLabelStyle:
+                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                indicatorSize: TabBarIndicatorSize.tab,
+                tabs: const [
+                  Tab(text: 'Request'),
+                  Tab(text: 'Response'),
+                  Tab(text: 'Error'),
+                  Tab(text: 'TryAgain'),
+                ]),
+          ),
         ));
   }
 }

--- a/lib/src/page/log_detail.dart
+++ b/lib/src/page/log_detail.dart
@@ -87,7 +87,11 @@ class _LogDetailState extends State<LogDetail> with SingleTickerProviderStateMix
                 labelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
                 unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
                 indicatorSize: TabBarIndicatorSize.tab,
-                indicator: CustomTabIndicator(color: Theme.of(context).primaryColor),
+                indicator: CustomTabIndicator(
+                  color: Theme.of(context).primaryColor,
+                  radius: 3,
+                  fixedWidth: 16,
+                ),
                 tabs: const [
                   Tab(text: 'Request'),
                   Tab(text: 'Response'),

--- a/lib/src/page/log_detail.dart
+++ b/lib/src/page/log_detail.dart
@@ -1,3 +1,5 @@
+import 'package:dio_log_viewer/src/widget/custom_tab_indicator.dart';
+
 import './error_page.dart';
 import './request_page.dart';
 import './response_page.dart';
@@ -7,18 +9,17 @@ import 'package:flutter/material.dart';
 
 class LogDetail extends StatefulWidget {
   final ResultEntity entity;
+
   const LogDetail({super.key, required this.entity});
 
   @override
   State<LogDetail> createState() => _LogDetailState();
 }
 
-class _LogDetailState extends State<LogDetail>
-    with SingleTickerProviderStateMixin {
+class _LogDetailState extends State<LogDetail> with SingleTickerProviderStateMixin {
   String title = 'Request';
 
-  late final TabController _tabController =
-      TabController(length: 4, vsync: this);
+  late final TabController _tabController = TabController(length: 4, vsync: this);
 
   @override
   void initState() {
@@ -60,8 +61,7 @@ class _LogDetailState extends State<LogDetail>
           title: Text(title),
         ),
         body: TabBarView(controller: _tabController, children: [
-          RequestPage(widget.entity.options, widget.entity.startTime!,
-              widget.entity.endTime),
+          RequestPage(widget.entity.options, widget.entity.startTime!, widget.entity.endTime),
           ResponsePage(widget.entity.response),
           ErrorPage(widget.entity.err),
           TryAgainPage(widget.entity)
@@ -84,11 +84,10 @@ class _LogDetailState extends State<LogDetail>
                 unselectedLabelColor: Colors.black,
                 labelColor: Theme.of(context).primaryColor,
                 indicatorPadding: const EdgeInsets.symmetric(horizontal: 20),
-                labelStyle:
-                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
-                unselectedLabelStyle:
-                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                labelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
                 indicatorSize: TabBarIndicatorSize.tab,
+                indicator: CustomTabIndicator(color: Theme.of(context).primaryColor),
                 tabs: const [
                   Tab(text: 'Request'),
                   Tab(text: 'Response'),

--- a/lib/src/widget/custom_tab_indicator.dart
+++ b/lib/src/widget/custom_tab_indicator.dart
@@ -2,49 +2,72 @@ import 'package:flutter/material.dart';
 
 class CustomTabIndicator extends Decoration {
   final Color color;
-  final double widthFactor;
+
+  // 固定宽度模式
+  final double? fixedWidth;
+
+  // 宽度比例
+  final double? widthFactor;
   final double indicatorSpacing;
   final double radius;
+  final double height;
 
   const CustomTabIndicator({
     required this.color,
-    this.widthFactor = 0.12,
+    this.fixedWidth,
+    this.widthFactor,
     this.indicatorSpacing = 8,
     this.radius = 4,
-  });
+    this.height = 3,
+  }) : assert(
+            fixedWidth != null || widthFactor != null, 'One of fixedWidth or widthFactor must be passed in.');
 
   @override
   BoxPainter createBoxPainter([VoidCallback? onChanged]) {
     return _CustomTabIndicatorPainter(
+      fixedWidth: fixedWidth,
       widthFactor: widthFactor,
       indicatorSpacing: indicatorSpacing,
       radius: radius,
       color: color,
+      height: height,
     );
   }
 }
 
 class _CustomTabIndicatorPainter extends BoxPainter {
-  final double widthFactor;
+  final double? fixedWidth;
+  final double? widthFactor;
   final double indicatorSpacing;
   final double radius;
+  final double height;
   final Color color;
 
   _CustomTabIndicatorPainter({
+    required this.fixedWidth,
     required this.widthFactor,
     required this.indicatorSpacing,
     required this.radius,
     required this.color,
+    required this.height,
   });
 
   @override
   void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
     assert(configuration.size != null);
-    final Rect rect = Offset(
-          offset.dx + configuration.size!.width * (1 - widthFactor) / 2,
-          offset.dy + configuration.size!.height - indicatorSpacing,
-        ) &
-        Size(configuration.size!.width * widthFactor, 3);
+
+    final tabWidth = configuration.size!.width;
+    final centerX = offset.dx + tabWidth / 2;
+
+    // 使用哪种模式
+    final double indicatorWidth = fixedWidth ?? (tabWidth * (widthFactor ?? 0.12)); // 默认0.12
+
+    final Rect rect = Rect.fromCenter(
+      center: Offset(centerX, offset.dy + configuration.size!.height - indicatorSpacing),
+      width: indicatorWidth,
+      height: height,
+    );
+
     final Paint paint = Paint()
       ..color = color
       ..style = PaintingStyle.fill;

--- a/lib/src/widget/custom_tab_indicator.dart
+++ b/lib/src/widget/custom_tab_indicator.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class CustomTabIndicator extends Decoration {
+  final Color color;
+  final double widthFactor;
+  final double indicatorSpacing;
+  final double radius;
+
+  const CustomTabIndicator({
+    required this.color,
+    this.widthFactor = 0.12,
+    this.indicatorSpacing = 8,
+    this.radius = 4,
+  });
+
+  @override
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) {
+    return _CustomTabIndicatorPainter(
+      widthFactor: widthFactor,
+      indicatorSpacing: indicatorSpacing,
+      radius: radius,
+      color: color,
+    );
+  }
+}
+
+class _CustomTabIndicatorPainter extends BoxPainter {
+  final double widthFactor;
+  final double indicatorSpacing;
+  final double radius;
+  final Color color;
+
+  _CustomTabIndicatorPainter({
+    required this.widthFactor,
+    required this.indicatorSpacing,
+    required this.radius,
+    required this.color,
+  });
+
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
+    assert(configuration.size != null);
+    final Rect rect = Offset(
+          offset.dx + configuration.size!.width * (1 - widthFactor) / 2,
+          offset.dy + configuration.size!.height - indicatorSpacing,
+        ) &
+        Size(configuration.size!.width * widthFactor, 3);
+    final Paint paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    canvas.drawRRect(
+      RRect.fromRectAndCorners(rect, topLeft: Radius.circular(radius), topRight: Radius.circular(radius)),
+      paint,
+    );
+  }
+}


### PR DESCRIPTION
今天在使用这个库时发现，TabBar使用indicatorPadding: const EdgeInsets.symmetric(horizontal: 20)后，因Error文字过短，长度计算不出，导致tab不显示问题，自定义了indicator